### PR TITLE
Update picomatch lockfiles to 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,9 +140,9 @@ path-key@^3.1.0:
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 readdirp@~3.6.0:
   version "3.6.0"


### PR DESCRIPTION
## Summary
- Updates the locked `picomatch` version from 2.3.1 to 2.3.2 in both npm and Yarn lockfiles.
- Keeps the package metadata and generated icons unchanged.

## Test plan
- Baseline: `npm ci` and `npm run build` passed before the change; `npm audit --audit-level=moderate` reported the existing picomatch advisory.
- `npm ci`
- `npm run build`
- `npm audit --audit-level=moderate`
- `npm ls picomatch --all`
- `npx -y yarn@1.22.22 install --frozen-lockfile --ignore-scripts`
- `npm pack --dry-run`
- `git diff --check`
